### PR TITLE
Update session cookie domain handling in fetchHandler

### DIFF
--- a/packages/animelist-auth/src/server/handlers/fetchHandler.ts
+++ b/packages/animelist-auth/src/server/handlers/fetchHandler.ts
@@ -112,6 +112,7 @@ async function handleAuth(event: RequestEvent, options: HandleAuthOptions) {
         sameSite: "lax",
         secure: dev === false,
         maxAge: sessionDurationSeconds,
+        domain: options.domain,
       });
 
       event.cookies.set(COOKIE_AUTH_CODE_CHALLENGE, codeChallenge, {
@@ -120,6 +121,7 @@ async function handleAuth(event: RequestEvent, options: HandleAuthOptions) {
         sameSite: "lax",
         secure: dev === false,
         maxAge: 60 * 15, // 15min
+        domain: options.domain,
       });
 
       // sign-in callback
@@ -128,10 +130,10 @@ async function handleAuth(event: RequestEvent, options: HandleAuthOptions) {
       throw redirect(307, authenticationUrl);
     }
     case "/sign-out": {
-      event.cookies.delete(COOKIE_AUTH_SESSION, { path: "/" });
-      event.cookies.delete(COOKIE_AUTH_CODE_CHALLENGE, { path: "/" });
-      event.cookies.delete(COOKIE_AUTH_ACCESS_TOKEN, { path: "/" });
-      event.cookies.delete(COOKIE_AUTH_CSRF, { path: "/" });
+      event.cookies.delete(COOKIE_AUTH_SESSION, { path: "/", domain: options.domain });
+      event.cookies.delete(COOKIE_AUTH_CODE_CHALLENGE, { path: "/", domain: options.domain });
+      event.cookies.delete(COOKIE_AUTH_ACCESS_TOKEN, { path: "/", domain: options.domain });
+      event.cookies.delete(COOKIE_AUTH_CSRF, { path: "/", domain: options.domain });
 
       // sign-out callback
       options.callbacks?.onSignOut?.(event);
@@ -179,6 +181,7 @@ async function handleAuth(event: RequestEvent, options: HandleAuthOptions) {
         secure: dev === false,
         sameSite: "lax",
         maxAge: sessionDurationSeconds,
+        domain: options.domain,
       });
 
       const { access_token: accessToken, expires_in } = await Auth.refreshToken({ refreshToken: tokens.refresh_token });
@@ -189,10 +192,11 @@ async function handleAuth(event: RequestEvent, options: HandleAuthOptions) {
         secure: dev === false,
         sameSite: "lax",
         maxAge: expires_in,
+        domain: options.domain,
       });
 
       // remove the auth code challenge cookie
-      event.cookies.delete(COOKIE_AUTH_CODE_CHALLENGE);
+      event.cookies.delete(COOKIE_AUTH_CODE_CHALLENGE, { domain: options.domain });
 
       // auth callback
       options.callbacks?.onCallback?.(event);
@@ -222,6 +226,7 @@ async function handleAuth(event: RequestEvent, options: HandleAuthOptions) {
         maxAge: sessionDurationSeconds,
         httpOnly: true,
         sameSite: "strict",
+        domain: options.domain,
       });
 
       // session callback

--- a/packages/animelist-auth/src/server/handlers/types.ts
+++ b/packages/animelist-auth/src/server/handlers/types.ts
@@ -79,6 +79,11 @@ export interface MyAnimeListHandlerOptions {
    * Callbacks.
    */
   callbacks?: AuthCallbacks;
+
+  /**
+   * Set the domain for the session cookie.
+   */
+  domain?: string;
 }
 
 export type HandleAuthOptions = MyAnimeListHandlerOptions & {


### PR DESCRIPTION
### Description
This pull request enhances the session management in the fetchHandler by introducing the ability to set a domain for session cookies. This change ensures that session cookies are correctly scoped to the specified domain, which is particularly useful for cross-domain authentication scenarios. The following updates were made:
- Added `domain` option to `MyAnimeListHandlerOptions` in `types.ts`.
- Modified `fetchHandler.ts` to include the `domain` parameter when setting and deleting cookies.

### Reasoning
The update addresses the need for flexible session cookie management across different domains, improving the authentication flow and ensuring consistency in cookie handling. This is particularly important for applications operating in a multi-domain environment, ensuring user sessions are correctly maintained and scoped.

### Files changed
- `fetchHandler.ts`: Added domain parameter to cookie set and delete operations.
- `types.ts`: Introduced domain option in `MyAnimeListHandlerOptions`.
By incorporating this change, the session management becomes more robust and adaptable to various deployment scenarios.